### PR TITLE
Add python3 compatibility for import

### DIFF
--- a/src/sparc/videotracking/processing.py
+++ b/src/sparc/videotracking/processing.py
@@ -7,7 +7,10 @@ import os
 import cv2
 
 from PIL import Image
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import numpy as np
 import scipy


### PR DESCRIPTION
StringIO is python 2 only, so we import io if it is not available